### PR TITLE
Fix: redmine plugin migrate sql error

### DIFF
--- a/db/migrate/003_add_trello_board_mapping_to_project.rb
+++ b/db/migrate/003_add_trello_board_mapping_to_project.rb
@@ -1,6 +1,6 @@
 class AddTrelloBoardMappingToProject < ActiveRecord::Migration
   def change
-    add_column :projects, :trello_mapping_redmine_statuses, :text, :default => "", :null => false
-    add_column :projects, :trello_mapping_trello_lists,     :text, :default => "", :null => false
+    add_column :projects, :trello_mapping_redmine_statuses, :text, :null => false
+    add_column :projects, :trello_mapping_trello_lists,     :text, :null => false
   end
 end


### PR DESCRIPTION
After moving the plugin directory from `redmine-trello-card-sync` to `redmine_trello_card_sync` (so I confirm the suggestions from #1 works), the migrate command `bundle exec rake redmine:plugins:migrate RAILS_ENV=production` didn't work and caused some mysql error.

This patch solves this.